### PR TITLE
restart scanner fix

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -19,7 +19,8 @@ public struct CodeScannerView: UIViewControllerRepresentable {
 
     public class ScannerCoordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         var parent: CodeScannerView
-        var codeFound = false
+        var scanInterval: Double = 2.0
+        var lastTime = Date(timeIntervalSince1970: 0)
 
         init(parent: CodeScannerView) {
             self.parent = parent
@@ -29,13 +30,15 @@ public struct CodeScannerView: UIViewControllerRepresentable {
             if let metadataObject = metadataObjects.first {
                 guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
                 guard let stringValue = readableObject.stringValue else { return }
-                guard codeFound == false else { return }
-
-                AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
-                found(code: stringValue)
-
-                // make sure we only trigger scans once per use
-                codeFound = true
+                foundCode(code: stringValue)
+            }
+        }
+        
+        func foundCode(code: String) {
+            let now = Date()
+            if now.timeIntervalSince(lastTime) >= scanInterval {
+                lastTime = now
+                self.found(code: code)
             }
         }
 


### PR DESCRIPTION
Fixed an issue where restart/reset scanner from the same view was not working because of codeFound condition. Removing this condition raised another problem of found(code:) being called multiple times for a single scan. To solve this issue, used scanInterval so that found(code:) not called multiple times.
