### PR TITLE
Avoid redundant reload when sheet is pulled down

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -181,7 +181,9 @@ public struct CodeScannerView: UIViewControllerRepresentable {
 
         override public func viewDidAppear(_ animated: Bool) {
             super.viewDidAppear(animated)
-            previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+            if previewLayer == nil {
+                previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+            }
             previewLayer.frame = view.layer.bounds
             previewLayer.videoGravity = .resizeAspectFill
             view.layer.addSublayer(previewLayer)
@@ -197,8 +199,8 @@ public struct CodeScannerView: UIViewControllerRepresentable {
             }
         }
 
-        override public func viewWillDisappear(_ animated: Bool) {
-            super.viewWillDisappear(animated)
+        override public func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(animated)
 
             if (captureSession?.isRunning == true) {
                 captureSession.stopRunning()


### PR DESCRIPTION
This is a fix for #11 where the video capture session restarts and the preview layer is reloaded because pulling down a sheet partially (not completely) fires `viewWillDisappear` and `viewDidAppear`.

I made the following changes:
1. Added a nil check to `viewDidAppear` to avoid redundant preview layer instantiation
2. Changed `viewWillDisappear` into `viewDidDisappear` so that the capture session won't stop until the sheet is completely pulled down and closed