### PR TITLE
Remove vibration playing after found the code

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -62,7 +62,6 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         
         func found(code: String) {
             lastTime = Date()
-            AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
             parent.completion(.success(code))
         }
 


### PR DESCRIPTION
I think the behavior that playing a vibration after found the code is out of the scope of this library. It's impossible to customize such as using haptic notification or beep sound.

I met this problem during to use to make our production app. 
In specific, I want to use `UINotificationFeedbackGenerator#notificationOccurred(.success)` after found the code, not the vibration which is too heavy and uncomfortable feedback.

CodeScanner already has a grate point to handle this: `completion: @escaping (Result<String, ScanError>) -> Void`.
The users can add their own logic in completion handler, so it's now more flexible.