### PR TITLE
Fix build for Xcode 13 beta 3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .target(
             name: "CodeScanner",
             dependencies: [],
-            resources: [.process("Recources")]),
+            resources: [.process("Resources")]),
         .testTarget(
             name: "CodeScannerTests",
             dependencies: ["CodeScanner"]),

--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -227,7 +227,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         }
 
         @objc func updateOrientation() {
-            guard let orientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation else { return }
+            guard let orientation = view.window?.windowScene?.interfaceOrientation else { return }
             guard let connection = captureSession.connections.last, connection.isVideoOrientationSupported else { return }
             connection.videoOrientation = AVCaptureVideoOrientation(rawValue: orientation.rawValue) ?? .portrait
         }


### PR DESCRIPTION
In beta 3, linking to Swift Packages using APIs normally unavailable to application extensions now results in a build error: cf https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes#Swift-Packages

This PR addresses the issue by replacing the use of `UIApplication.shared` (which is indeed unavailable to app extensions) with a view controller API.