### PR TITLE
Reset the ScannerController on viewWillAppear

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -32,6 +32,13 @@ public struct CodeScannerView: UIViewControllerRepresentable {
             self.codesFound = Set<String>()
         }
 
+        public func reset()
+        {
+            self.codesFound = Set<String>()
+            self.isFinishScanning = false
+            self.lastTime = Date(timeIntervalSince1970: 0)
+        }
+
         public func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
             if let metadataObject = metadataObjects.first {
                 guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
@@ -247,6 +254,8 @@ public struct CodeScannerView: UIViewControllerRepresentable {
             previewLayer.videoGravity = .resizeAspectFill
             view.layer.addSublayer(previewLayer)
             addviewfinder()
+
+            delegate?.reset()
 
             if (captureSession?.isRunning == false) {
                 captureSession.startRunning()


### PR DESCRIPTION
When the CodeScannerView is used in a navigation stack, if you navigate
*back* to it it will no longer scan any codes (because
isFinishedScanning is true). This changes it so that we reset the state
of the ScannerController when the view apepars, so that it's ready to
be reused.