### PR TITLE
Add support for use with macOS Catalyst (14.0+)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "CodeScanner",
     platforms: [
-      .iOS(.v13)
+      .iOS(.v13),
+      .macOS(.v11)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// To use, set `codeTypes` to be an array of things to scan for, e.g. `[.qr]`, and set `completion` to
 /// a closure that will be called when scanning has finished. This will be sent the string that was detected or a `ScanError`.
 /// For testing inside the simulator, set the `simulatedData` property to some test data you want to send back.
+@available(macCatalyst 14.0, *)
 public struct CodeScannerView: UIViewControllerRepresentable {
     public enum ScanError: Error {
         case badInput, badOutput
@@ -352,6 +353,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
     }
 }
 
+@available(macCatalyst 14.0, *)
 struct CodeScannerView_Previews: PreviewProvider {
     static var previews: some View {
         CodeScannerView(codeTypes: [.qr]) { result in


### PR DESCRIPTION
Fixes #33.

This adds macOS 11 as a platform (== macCatalyst v14.0), which prevents linking failures, and marks the classes as available from macCatalyst 14.0+ which prevents compile failures.

A `#available` directive cannot be used, as a swift package is compiled and linked regardless of the importing project's target SDK.