### PR TITLE
Add missing rights check

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// For testing inside the simulator, set the `simulatedData` property to some test data you want to send back.
 public struct CodeScannerView: UIViewControllerRepresentable {
     public enum ScanError: Error {
-        case badInput, badOutput
+        case badInput, badOutput, missingRights
     }
     
     public enum ScanMode {
@@ -207,7 +207,10 @@ public struct CodeScannerView: UIViewControllerRepresentable {
                 return
             }
 
-            guard let videoInput = try? AVCaptureDeviceInput(device: videoCaptureDevice) else { return }
+            guard let videoInput = try? AVCaptureDeviceInput(device: videoCaptureDevice) else {
+                delegate?.didFail(reason: .missingRights)
+                return
+            }
 
             if (captureSession.canAddInput(videoInput)) {
                 captureSession.addInput(videoInput)

--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// For testing inside the simulator, set the `simulatedData` property to some test data you want to send back.
 public struct CodeScannerView: UIViewControllerRepresentable {
     public enum ScanError: Error {
-        case badInput, badOutput, missingRights
+        case badInput, badOutput, initError(_ error: Error)
     }
     
     public enum ScanMode {
@@ -207,8 +207,11 @@ public struct CodeScannerView: UIViewControllerRepresentable {
                 return
             }
 
-            guard let videoInput = try? AVCaptureDeviceInput(device: videoCaptureDevice) else {
-                delegate?.didFail(reason: .missingRights)
+            let videoInput: AVCaptureDeviceInput
+            do {
+                videoInput = try AVCaptureDeviceInput(device: videoCaptureDevice)
+            } catch {
+                delegate?.didFail(reason: .initError(error))
                 return
             }
 


### PR DESCRIPTION
After using this library in my project I found out, that there is currently no way to detect if the user has not granted permissions to the camera. This results in only a black screen for the CodeScannerView.

This PR adds an error case for missing rights, so the developer can update the UI to inform the user about the missing right. This might not be the cleanest implementation as it will always return the missingRights error for every error that occurred during initialization of init of `AVCaptureDeviceInput`. It works well for my case so far and is a purely additive change.

Do you mind merging this and releasing a new version @twostraws ? It has been a while since 1.0.7 and quite some new features were added (like viewfinder support)...