### PR TITLE
Proper permission denied error if camera access is denied

### DIFF
--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -202,8 +202,10 @@ extension CodeScannerView {
 
         private func handleCameraPermission() {
             switch AVCaptureDevice.authorizationStatus(for: .video) {
-                case .denied, .restricted:
+                case .restricted:
                     break
+                case .denied:
+                    self.delegate?.didFail(reason: .permissionDenied)
                 case .notDetermined:
                     self.requestCameraAccess {
                         self.setupCaptureDevice()


### PR DESCRIPTION
Currently we fail only with `.permissionDenied` after requesting camera access (and not getting any). If camera access is already denied the error is swallowed.