### PR TITLE
[#89] Use the Ultra WIde Camera per default if available

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -115,16 +115,6 @@ public struct CodeScannerView: UIViewControllerRepresentable {
     
 }
 
-public extension AVCaptureDevice {
-    
-    /// This returns the Ultra Wide Camera on capable devices and the default Camera for Video otherwise.
-    static var bestForVideo: AVCaptureDevice? {
-        let deviceHasUltraWideCamera = !AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInUltraWideCamera], mediaType: .video, position: .back).devices.isEmpty
-        return deviceHasUltraWideCamera ? AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) : AVCaptureDevice.default(for: .video)
-    }
-    
-}
-
 @available(macCatalyst 14.0, *)
 struct CodeScannerView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -83,7 +83,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         shouldVibrateOnSuccess: Bool = true,
         isTorchOn: Bool = false,
         isGalleryPresented: Binding<Bool> = .constant(false),
-        videoCaptureDevice: AVCaptureDevice? = AVCaptureDevice.default(for: .video),
+        videoCaptureDevice: AVCaptureDevice? = AVCaptureDevice.bestForVideo,
         completion: @escaping (Result<ScanResult, ScanError>) -> Void
     ) {
         self.codeTypes = codeTypes
@@ -111,6 +111,16 @@ public struct CodeScannerView: UIViewControllerRepresentable {
             isManualCapture: scanMode == .manual,
             isManualSelect: manualSelect
         )
+    }
+    
+}
+
+public extension AVCaptureDevice {
+    
+    /// This returns the Ultra Wide Camera on capable devices and the default Camera for Video otherwise.
+    static var bestForVideo: AVCaptureDevice? {
+        let deviceHasUltraWideCamera = !AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInUltraWideCamera], mediaType: .video, position: .back).devices.isEmpty
+        return deviceHasUltraWideCamera ? AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) : AVCaptureDevice.default(for: .video)
     }
     
 }

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -524,3 +524,14 @@ extension CodeScannerView.ScannerViewController: AVCapturePhotoCaptureDelegate {
     }
     
 }
+
+@available(macCatalyst 14.0, *)
+public extension AVCaptureDevice {
+    
+    /// This returns the Ultra Wide Camera on capable devices and the default Camera for Video otherwise.
+    static var bestForVideo: AVCaptureDevice? {
+        let deviceHasUltraWideCamera = !AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInUltraWideCamera], mediaType: .video, position: .back).devices.isEmpty
+        return deviceHasUltraWideCamera ? AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) : AVCaptureDevice.default(for: .video)
+    }
+    
+}


### PR DESCRIPTION
Autofocus on devices that are equipped with an Ultra Wide Camera seems to be off using the default Camera. This is why we select the Ultra Wide Camera per default now.

Fixes #89 