### PR TITLE
manual torch button added for flashlight at the time of scan QR code

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -71,7 +71,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
     public let showViewfinder: Bool
     public var simulatedData = ""
     public var shouldVibrateOnSuccess: Bool
-    public var isTorchOn: Bool
+    public var manualTorch: Bool
     public var isGalleryPresented: Binding<Bool>
     public var videoCaptureDevice: AVCaptureDevice?
     public var completion: (Result<ScanResult, ScanError>) -> Void
@@ -84,7 +84,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         showViewfinder: Bool = false,
         simulatedData: String = "",
         shouldVibrateOnSuccess: Bool = true,
-        isTorchOn: Bool = false,
+        manualTorch: Bool = false,
         isGalleryPresented: Binding<Bool> = .constant(false),
         videoCaptureDevice: AVCaptureDevice? = AVCaptureDevice.bestForVideo,
         completion: @escaping (Result<ScanResult, ScanError>) -> Void
@@ -96,7 +96,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         self.scanInterval = scanInterval
         self.simulatedData = simulatedData
         self.shouldVibrateOnSuccess = shouldVibrateOnSuccess
-        self.isTorchOn = isTorchOn
+        self.manualTorch = manualTorch
         self.isGalleryPresented = isGalleryPresented
         self.videoCaptureDevice = videoCaptureDevice
         self.completion = completion
@@ -109,10 +109,10 @@ public struct CodeScannerView: UIViewControllerRepresentable {
     public func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {
         uiViewController.parentView = self
         uiViewController.updateViewController(
-            isTorchOn: isTorchOn,
             isGalleryPresented: isGalleryPresented.wrappedValue,
             isManualCapture: scanMode == .manual,
-            isManualSelect: manualSelect
+            isManualSelect: manualSelect,
+            isManualTorch: manualTorch
         )
     }
     


### PR DESCRIPTION
- When I tried to implement this CodeScanner I found there is no manual button to turn on/off the torch at the time of Scanning QR code.

- So, On the basis of that I create this branch with manual button on ui to turn on/off torch  at the time of Scanning QR code. It is a small feature but it is very useful for users. 

- Previously we have only option to turn on torch at the time of initialisation of CodeScannerView. And due to this flashlight gets automatically on for longer time. Which I found very unknowing feature.

- If user will have button to turn ON/OFF torch or flashlight at the time of scanning QR code it will be very helpful for them.

- I hope this could be add on feature for this Code Scanner.