### PR TITLE
Add privacy manifest file

### DIFF
--- a/Sources/CodeScanner/PrivacyInfo.xcprivacy
+++ b/Sources/CodeScanner/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false />
+    <key>NSPrivacyTrackingDomains</key>
+    <array />
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array />
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>CA92.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>


### PR DESCRIPTION
Since the app doesn't track or use users' information, I added this default privacy manifest file to prevent Apple warnings