### PR TITLE
Support Xcode preview for multi-platform project

### DIFF
--- a/Sources/CodeScanner/AVCaptureDevice+bestForBuiltInCamera.swift
+++ b/Sources/CodeScanner/AVCaptureDevice+bestForBuiltInCamera.swift
@@ -7,7 +7,7 @@
 //
 
 import AVFoundation
-
+#if os(iOS)
 @available(macCatalyst 14.0, *)
 extension AVCaptureDevice {
     
@@ -123,3 +123,4 @@ private extension Float {
 
  Copyright (C) 2016 Apple Inc. All Rights Reserved.
  */
+#endif

--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -9,6 +9,7 @@
 import AVFoundation
 import SwiftUI
 
+#if os(iOS)
 /// An enum describing the ways CodeScannerView can hit scanning problems.
 public enum ScanError: Error {
     /// The camera could not be accessed.
@@ -153,3 +154,4 @@ struct CodeScannerView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -7,8 +7,11 @@
 //
 
 import AVFoundation
+#if canImport(UIKit)
 import UIKit
+#endif
 
+#if os(iOS)
 @available(macCatalyst 14.0, *)
 extension CodeScannerView {
     
@@ -594,3 +597,4 @@ public extension AVCaptureDevice {
     }
     
 }
+#endif


### PR DESCRIPTION
There's a bug in Xcode Preview when you have a multi-platform project. When you set build destination other than iOS on preview in such project, Xcode Preview tries to build depended packages that does not support those platforms even you set _not_ build those packages in Xcode. (more detail about this bug, please read: https://stackoverflow.com/questions/71334194/swiftui-preview-incorrectly-tries-to-build-conditional-dependency-from-another-p and https://forums.swift.org/t/swiftpm-platform-conditional-target-dependancy-not-resolved-for-tvos/56767)

This PR adds `#if os(iOS) ~ #endif` to the source files so it passes build on mac target.