### PR TITLE
Add support for adding this lib to multi-platform targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,20 +8,18 @@ on:
 
 jobs:
   build:
-
     runs-on: macos-latest
-
     steps:
     - uses: actions/checkout@v2
-
     - name: Select Xcode Version
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
-
     - name: Show eligible build destinations
       run: xcodebuild -showdestinations -scheme CodeScanner
     - name: Build ( iOS)
       run: xcodebuild build -scheme CodeScanner -destination 'platform=iOS Simulator,OS=latest,name=iPhone 13 Pro'
+    - name: Build ( visionOS)
+      run: xcodebuild build -scheme CodeScanner -destination 'platform=visionOS Simulator,OS=latest,name=Apple Vision Pro'
     - name: Build ( mac Catalyst)
       run: xcodebuild build -scheme CodeScanner -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst'

--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,10 @@
-// swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
     name: "CodeScanner",
-    platforms: [
-      .iOS(.v13)
-    ],
-    products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "CodeScanner",
-            targets: ["CodeScanner"]),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "CodeScanner",
-            dependencies: []),
-    ]
+    platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .visionOS(.v1), .watchOS(.v6)],
+    products: [.library(name: "CodeScanner", targets: ["CodeScanner"])],
+    dependencies: [],
+    targets: [.target(name: "CodeScanner", dependencies: [])]
 )

--- a/Sources/CodeScanner/AVCaptureDevice+bestForBuiltInCamera.swift
+++ b/Sources/CodeScanner/AVCaptureDevice+bestForBuiltInCamera.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Paul Hudson. All rights reserved.
 //
 
+#if os(iOS)
 import AVFoundation
 
 @available(macCatalyst 14.0, *)
@@ -79,6 +80,7 @@ private extension Float {
         self * Float.pi / 180
     }
 }
+#endif
 
 /*
  Part of this code is copied from Apple sample project "AVCamBarcode: Using AVFoundation to capture barcodes".

--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Paul Hudson. All rights reserved.
 //
 
+#if os(iOS)
 import AVFoundation
 import SwiftUI
 
@@ -153,3 +154,4 @@ struct CodeScannerView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Paul Hudson. All rights reserved.
 //
 
+#if os(iOS)
 import AVFoundation
 import UIKit
 
@@ -594,3 +595,4 @@ public extension AVCaptureDevice {
     }
     
 }
+#endif


### PR DESCRIPTION
I'm working on a new app that is available on all Apple platforms. But only on iOS I want to use this library to securely transfer some credentials from the Mac app to the iPhone app. But due to limitations in SwiftPM or Xcodes build system, it's not possible to include this package to a multi-platform project and just to link it when building for iOS. I'd need to create multiple targets to do that, which I don't want to do as it's a SwiftUI app and I like to keep things simple & clean.

This PR adds building support for other Apple platforms by specifying compatibility in the Package manifest while basically commenting out all code when those platforms are targeted during a build.

I'd understand if you don't want to merge this. But I needed it, so I figured maybe others may need it as well.
Thank you for providing this great lib, it was a huge time saver!