### PR TITLE
Fix issue capture and select buttons disappearing on load

### DIFF
--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -187,7 +187,8 @@ extension CodeScannerView {
             previewLayer.videoGravity = .resizeAspectFill
             view.layer.addSublayer(previewLayer)
             addViewFinder()
-
+            addManualButtons()
+            
             reset()
 
             if !captureSession.isRunning {
@@ -289,6 +290,11 @@ extension CodeScannerView {
                 imageView.heightAnchor.constraint(equalToConstant: 200),
             ])
         }
+        
+        private func addManualButtons() {
+            self.view.bringSubviewToFront(self.manualCaptureButton)
+            self.view.bringSubviewToFront(self.manualSelectButton)
+        }
 
         override public func viewDidDisappear(_ animated: Bool) {
             super.viewDidDisappear(animated)
@@ -353,7 +359,6 @@ extension CodeScannerView {
                 ])
             }
             
-            view.bringSubviewToFront(manualCaptureButton)
             manualCaptureButton.isHidden = !isManualCapture
         }
         
@@ -368,7 +373,6 @@ extension CodeScannerView {
                 ])
             }
             
-            view.bringSubviewToFront(manualSelectButton)
             manualSelectButton.isHidden = !isManualSelect
         }
         #endif

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -138,7 +138,6 @@ extension CodeScannerView {
         override public func viewDidLoad() {
             super.viewDidLoad()
             self.addOrientationDidChangeObserver()
-            self.addSessionDidChangeObserver()
             self.setBackgroundColor()
             self.handleCameraPermission()
         }
@@ -161,13 +160,6 @@ extension CodeScannerView {
                 connection.videoOrientation = .portraitUpsideDown
             default:
                 connection.videoOrientation = .portrait
-            }
-        }
-        
-        @objc private func onCaptureSessionStarted() {
-            DispatchQueue.main.async {
-                self.view.bringSubviewToFront(self.manualCaptureButton)
-                self.view.bringSubviewToFront(self.manualSelectButton)
             }
         }
 
@@ -242,15 +234,6 @@ extension CodeScannerView {
                 self,
                 selector: #selector(updateOrientation),
                 name: UIDevice.orientationDidChangeNotification,
-                object: nil
-            )
-        }
-        
-        private func addSessionDidChangeObserver() {
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(onCaptureSessionStarted),
-                name: NSNotification.Name.AVCaptureSessionDidStartRunning,
                 object: nil
             )
         }
@@ -370,6 +353,7 @@ extension CodeScannerView {
                 ])
             }
             
+            view.bringSubviewToFront(manualCaptureButton)
             manualCaptureButton.isHidden = !isManualCapture
         }
         
@@ -384,6 +368,7 @@ extension CodeScannerView {
                 ])
             }
             
+            view.bringSubviewToFront(manualSelectButton)
             manualSelectButton.isHidden = !isManualSelect
         }
         #endif

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -138,6 +138,7 @@ extension CodeScannerView {
         override public func viewDidLoad() {
             super.viewDidLoad()
             self.addOrientationDidChangeObserver()
+            self.addSessionDidChangeObserver()
             self.setBackgroundColor()
             self.handleCameraPermission()
         }
@@ -160,6 +161,13 @@ extension CodeScannerView {
                 connection.videoOrientation = .portraitUpsideDown
             default:
                 connection.videoOrientation = .portrait
+            }
+        }
+        
+        @objc private func onCaptureSessionStarted() {
+            DispatchQueue.main.async {
+                self.view.bringSubviewToFront(self.manualCaptureButton)
+                self.view.bringSubviewToFront(self.manualSelectButton)
             }
         }
 
@@ -234,6 +242,15 @@ extension CodeScannerView {
                 self,
                 selector: #selector(updateOrientation),
                 name: UIDevice.orientationDidChangeNotification,
+                object: nil
+            )
+        }
+        
+        private func addSessionDidChangeObserver() {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(onCaptureSessionStarted),
+                name: NSNotification.Name.AVCaptureSessionDidStartRunning,
                 object: nil
             )
         }
@@ -353,7 +370,6 @@ extension CodeScannerView {
                 ])
             }
             
-            view.bringSubviewToFront(manualCaptureButton)
             manualCaptureButton.isHidden = !isManualCapture
         }
         
@@ -368,7 +384,6 @@ extension CodeScannerView {
                 ])
             }
             
-            view.bringSubviewToFront(manualSelectButton)
             manualSelectButton.isHidden = !isManualSelect
         }
         #endif


### PR DESCRIPTION
Because updateViewController() is being called before the previewLayer is added to the view, we get an issue where the manual capture buttons disappear on load.

To fix it, we only bring the buttons to the front of the view after the previewLayer is added. Note that we only bring the buttons to front, the visibility of the buttons themselves are still begin handled in showManualCaptureButton() and showManualSelectButton() respectively.