### PR TITLE
Dispatch failure on main queue to prevent crash

### DIFF
--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -425,7 +425,9 @@ extension CodeScannerView {
         }
 
         func didFail(reason: ScanError) {
-            parentView.completion(.failure(reason))
+            DispatchQueue.main.async {
+                self.parentView.completion(.failure(reason))
+            }
         }
         
     }


### PR DESCRIPTION
This change solves a fix I was able to reproduce consistency by denying access to the camera when prompted.
I have verified the fix (i.e. the crash does not happen anymore).

Stack trace of the crash I was experiencing:
```
Crashed: com.apple.coremedia.capture.tccserver
0  libdispatch.dylib              0x64d8 _dispatch_assert_queue_fail + 120
1  libdispatch.dylib              0x6460 _dispatch_assert_queue_fail + 194
2  libswift_Concurrency.dylib     0x62b58 swift_task_isCurrentExecutorImpl(swift::SerialExecutorRef) + 284
3  [redacted]                     0x5239f4 closure #2 in closure #1 in [redacted].body.getter + 4373346804 (<stdin>:4373346804)
4  [redacted]                     0x6030ac closure #1 in CodeScannerView.ScannerViewController.requestCameraAccess(completion:) + 428 (ScannerViewController.swift:428)
5  [redacted]                     0x6030fc thunk for @escaping @callee_guaranteed (@unowned Bool) -> () + 4374262012 (<compiler-generated>:4374262012)
6  TCC                            0xfa24 ___tcc_server_send_request_authorization_block_invoke.83 + 40
7  libdispatch.dylib              0x2370 _dispatch_call_block_and_release + 32
8  libdispatch.dylib              0x40d0 _dispatch_client_callout + 20
9  libdispatch.dylib              0xb6d8 _dispatch_lane_serial_drain + 744
10 libdispatch.dylib              0xc1e0 _dispatch_lane_invoke + 380
11 libdispatch.dylib              0x17258 _dispatch_root_queue_drain_deferred_wlh + 288
12 libdispatch.dylib              0x16aa4 _dispatch_workloop_worker_thread + 540
13 libsystem_pthread.dylib        0x4c7c _pthread_wqthread + 288
14 libsystem_pthread.dylib        0x1488 start_wqthread + 8
```

Crash info from Crashlytics:
```
BUG IN CLIENT OF LIBDISPATCH: Assertion failed: Block was expected to execute on queue [com.apple.main-thread (0x1f36f0880)]
```