### PR TITLE
Update the orientation of the previewLayer connection

### DIFF
--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -103,7 +103,7 @@ extension CodeScannerView {
         #else
         
         var captureSession: AVCaptureSession?
-        var previewLayer: AVCaptureVideoPreviewLayer!
+        var previewLayer: AVCaptureVideoPreviewLayer?
 
         private lazy var viewFinder: UIImageView? = {
             guard let image = UIImage(named: "viewfinder", in: .module, with: nil) else {
@@ -148,7 +148,7 @@ extension CodeScannerView {
 
         @objc func updateOrientation() {
             guard let orientation = view.window?.windowScene?.interfaceOrientation else { return }
-            guard let connection = captureSession?.connections.last, connection.isVideoOrientationSupported else { return }
+            guard let previewLayer, let connection = previewLayer.connection, connection.isVideoOrientationSupported else { return }
             switch orientation {
             case .portrait:
                 connection.videoOrientation = .portrait
@@ -183,8 +183,10 @@ extension CodeScannerView {
                 previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
             }
 
+            let previewLayer = self.previewLayer!
             previewLayer.frame = view.layer.bounds
             previewLayer.videoGravity = .resizeAspectFill
+            updateOrientation()
             view.layer.addSublayer(previewLayer)
             addViewFinder()
 


### PR DESCRIPTION
I was seeing the CodeScanner appearing not correctly rotated on iPad in landscape mode in a sheet (both on my test device and on a device of a user).
I found the code in CodeScannerController#updateOrientation and saw the orientation being set correctly to landscapeRight.
For some strange reason, it then started work on my test device (without a code change).
I guess the updateOrientation routine is flaky in some kind and saw that captureSession?.connections.count was 3 and wondered if the last connection is always the correct one to update.
I don't know a lot about AVCaptureSession, but on first sight it seems a better choice to update previewLayer.connection instead.