### PR TITLE
Correctly update the video orientation after the permission prompt appeared

### DIFF
--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -103,7 +103,7 @@ extension CodeScannerView {
         #else
         
         var captureSession: AVCaptureSession?
-        var previewLayer: AVCaptureVideoPreviewLayer!
+        var previewLayer: AVCaptureVideoPreviewLayer?
 
         private lazy var viewFinder: UIImageView? = {
             guard let image = UIImage(named: "viewfinder", in: .module, with: nil) else {
@@ -148,7 +148,7 @@ extension CodeScannerView {
 
         @objc func updateOrientation() {
             guard let orientation = view.window?.windowScene?.interfaceOrientation else { return }
-            guard let connection = captureSession?.connections.last, connection.isVideoOrientationSupported else { return }
+            guard let previewLayer, let connection = previewLayer.connection, connection.isVideoOrientationSupported else { return }
             switch orientation {
             case .portrait:
                 connection.videoOrientation = .portrait
@@ -183,8 +183,10 @@ extension CodeScannerView {
                 previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
             }
 
+            let previewLayer = self.previewLayer!
             previewLayer.frame = view.layer.bounds
             previewLayer.videoGravity = .resizeAspectFill
+            updateOrientation()
             view.layer.addSublayer(previewLayer)
             addViewFinder()
 


### PR DESCRIPTION
- When the permission prompt appears, updateOrientation was called before the AV connection was established and the orientation was not updated afterwards when the connection is available
- Update previewLayer.connection instead of captureSession?.connections.last
- Remove implicit forced unwrap for previewLayer property