### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can provide a variety of extra customization options to `CodeScannerView` in
 - `simulatedData` allows you to provide some test data to use in Simulator, when real scanning isn’t available. Default: an empty string.
 - `shouldVibrateOnSuccess` allows you to determine whether device should vibrate when a code is found. Default: true.
 - `videoCaptureDevice` allows you to choose different capture device that is most suitable for code to scan.
-- `isTorchOn` turns on the phone’s torch/flashlight.
+- `isTorchOn` turns on/off the phone’s torch/flashlight. Default: `false`
 
 If you want to add UI customization, such as a dedicated Cancel button, you should wrap your `CodeScannerView` instance in a `NavigationView` and use a `toolbar()` modifier to add whatever buttons you want.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ You can provide a variety of extra customization options to `CodeScannerView` in
 - `showViewfinder` determines whether to show a box-like viewfinder over the UI. Default: false.
 - `simulatedData` allows you to provide some test data to use in Simulator, when real scanning isn’t available. Default: an empty string.
 - `shouldVibrateOnSuccess` allows you to determine whether device should vibrate when a code is found. Default: true.
-- `videoCaptureDevice` allows you to choose different capture device that is most suitable for code to scan. 
+- `videoCaptureDevice` allows you to choose different capture device that is most suitable for code to scan.
+- `isTorchOn` turns on the phone’s torch/flashlight.
 
 If you want to add UI customization, such as a dedicated Cancel button, you should wrap your `CodeScannerView` instance in a `NavigationView` and use a `toolbar()` modifier to add whatever buttons you want.
 


### PR DESCRIPTION
### Change Proposed
Add `isTorchOn` in the README

### Explanation
I was using this library and wanted to add a button to turn on the phone’s torch on the same screen. At the time I didn't know  `isTorch` option, so I tried to do it following [this stackoverflow post](https://stackoverflow.com/q/27207278), but none of them works as expected. It worked until I tried to comment out the code of `CodeScanner`, and then I discovered this option. Therefore I think it's one of the most important options for us developers.