### PR TITLE
Add source and bounding rect to ScanResult

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -35,12 +35,20 @@ public struct ScanResult {
 
     /// The type of code that was matched.
     public let type: AVMetadataObject.ObjectType
-    
-    /// The image of the code that was matched
+
+    /// The source of the image where the code was scanned.
+    public let source: ScanSource
+
+    /// The image of the code that was matched.
     public let image: UIImage?
   
     /// The corner coordinates of the scanned code.
     public let corners: [CGPoint]
+
+    /// The bounding rectangle that contains the code that was scanned.
+    /// When the source is camera the rect is within the local coordinate space of the scanner view.
+    /// When the source is gallery the rect is in image coordinates.
+    public let boundingRect: CGRect
 }
 
 /// The operating mode for CodeScannerView.
@@ -68,6 +76,15 @@ public enum ScanMode {
             return false
         }
     }
+}
+
+/// The image source of the ScanResult.
+public enum ScanSource {
+    /// The image was captured by the camera represented by the provided or default `AVCaptureDevice`.
+    case camera
+
+    /// The image was provided by the user's photo gallery using `UIImagePickerController`.
+    case gallery
 }
 
 /// A SwiftUI view that is able to scan barcodes, QR codes, and more, and send back what was found.

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -58,6 +58,8 @@ extension CodeScannerView {
         }
 
         #if targetEnvironment(simulator)
+        var previewLayer: AVCaptureVideoPreviewLayer?
+
         override public func loadView() {
             view = UIView()
             view.isUserInteractionEnabled = true
@@ -96,7 +98,7 @@ extension CodeScannerView {
             // Send back their simulated data, as if it was one of the types they were scanning for
             found(ScanResult(
                 string: parentView.simulatedData,
-                type: parentView.codeTypes.first ?? .qr, image: nil, corners: []
+                type: parentView.codeTypes.first ?? .qr, source: .gallery, image: nil, corners: [], boundingRect: .zero
             ))
         }
         
@@ -374,11 +376,8 @@ extension CodeScannerView {
         #endif
         
         func updateViewController(isTorchOn: Bool, isGalleryPresented: Bool, isManualCapture: Bool, isManualSelect: Bool) {
-            guard let videoCaptureDevice = parentView.videoCaptureDevice ?? fallbackVideoCaptureDevice else {
-                return
-            }
-            
-            if videoCaptureDevice.hasTorch {
+            if let videoCaptureDevice = parentView.videoCaptureDevice ?? fallbackVideoCaptureDevice,
+               videoCaptureDevice.hasTorch {
                 try? videoCaptureDevice.lockForConfiguration()
                 videoCaptureDevice.torchMode = isTorchOn ? .on : .off
                 videoCaptureDevice.unlockForConfiguration()
@@ -445,7 +444,7 @@ extension CodeScannerView.ScannerViewController: AVCaptureMetadataOutputObjectsD
               !didFinishScanning,
               !isCapturing,
               let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject,
-              let boundingRect = previewLayer.transformedMetadataObject(for: metadataObject)?.bounds,
+              let boundingRect = previewLayer?.transformedMetadataObject(for: metadataObject)?.bounds,
               let stringValue = readableObject.stringValue else {
 
             return

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -445,6 +445,7 @@ extension CodeScannerView.ScannerViewController: AVCaptureMetadataOutputObjectsD
               !didFinishScanning,
               !isCapturing,
               let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject,
+              let boundingRect = previewLayer.transformedMetadataObject(for: metadataObject)?.bounds,
               let stringValue = readableObject.stringValue else {
 
             return
@@ -452,7 +453,7 @@ extension CodeScannerView.ScannerViewController: AVCaptureMetadataOutputObjectsD
 
         handler = { [weak self] image in
             guard let self else { return }
-            let result = ScanResult(string: stringValue, type: readableObject.type, image: image, corners: readableObject.corners)
+            let result = ScanResult(string: stringValue, type: readableObject.type, source: .camera, image: image, corners: readableObject.corners, boundingRect: boundingRect)
 
             switch parentView.scanMode {
             case .once:
@@ -530,7 +531,7 @@ extension CodeScannerView.ScannerViewController: UIImagePickerControllerDelegate
                 feature.topLeft
             ]
 
-            let result = ScanResult(string: qrCodeLink, type: .qr, image: qrcodeImg, corners: corners)
+            let result = ScanResult(string: qrCodeLink, type: .qr, source: .gallery, image: qrcodeImg, corners: corners, boundingRect: feature.bounds)
             found(result)
         }
     }


### PR DESCRIPTION
These two changes allow you to know where the `ScanResult` came from (`camera` vs `gallery`) and where within the scanner/gallery image the match was found. In my experience this was much more straightforward to work with than the `corners` property.

In my use case this was necessary because I am overlaying my own custom viewfinder and want to ignore scan results from outside the viewfinder when the source is `camera`. I can use the bounding rect and compare it to the frame of my custom viewfinder.

This also fixes an issue where the `isGalleryPresented` binding wasn't updating properly on simulators.